### PR TITLE
bump spring boot to 2.7 and use AutoConfiguration.imports

### DIFF
--- a/opentracing-spring-tracer-configuration-starter/pom.xml
+++ b/opentracing-spring-tracer-configuration-starter/pom.xml
@@ -50,6 +50,10 @@
       <groupId>org.springframework</groupId>
       <artifactId>spring-core</artifactId>
     </dependency>
+    <dependency>
+      <groupId>jakarta.annotation</groupId>
+      <artifactId>jakarta.annotation-api</artifactId>
+    </dependency>
 
     <dependency>
       <groupId>junit</groupId>

--- a/opentracing-spring-tracer-configuration-starter/src/main/resources/META-INF/spring.factories
+++ b/opentracing-spring-tracer-configuration-starter/src/main/resources/META-INF/spring.factories
@@ -1,3 +1,0 @@
-org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
-io.opentracing.contrib.spring.tracer.configuration.TracerAutoConfiguration,\
-io.opentracing.contrib.spring.tracer.configuration.TracerRegisterAutoConfiguration

--- a/opentracing-spring-tracer-configuration-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/opentracing-spring-tracer-configuration-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,2 @@
+io.opentracing.contrib.spring.tracer.configuration.TracerAutoConfiguration
+io.opentracing.contrib.spring.tracer.configuration.TracerRegisterAutoConfiguration

--- a/opentracing-spring-tracer-configuration-starter/src/test/java/io/opentracing/contrib/spring/tracer/configuration/TracerAutoConfigurationTest.java
+++ b/opentracing-spring-tracer-configuration-starter/src/test/java/io/opentracing/contrib/spring/tracer/configuration/TracerAutoConfigurationTest.java
@@ -25,6 +25,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 @SpringBootTest(
@@ -32,6 +33,7 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
             BaseTest.SpringConfiguration.class,
             TracerAutoConfigurationTest.SpringConfiguration.class})
 @RunWith(SpringJUnit4ClassRunner.class)
+@DirtiesContext
 public class TracerAutoConfigurationTest extends BaseTest {
 
   @Autowired

--- a/opentracing-spring-tracer-configuration-starter/src/test/java/io/opentracing/contrib/spring/tracer/configuration/TracerAutoConfigurationWithWrapperAndRegisteredTracerTest.java
+++ b/opentracing-spring-tracer-configuration-starter/src/test/java/io/opentracing/contrib/spring/tracer/configuration/TracerAutoConfigurationWithWrapperAndRegisteredTracerTest.java
@@ -24,6 +24,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 @SpringBootTest(
@@ -32,6 +33,7 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
             TracerAutoConfigurationWithWrapperAndRegisteredTracerTest.SpringConfiguration.class,
             TestTracerBeanPostProcessor.class})
 @RunWith(SpringJUnit4ClassRunner.class)
+@DirtiesContext
 public class TracerAutoConfigurationWithWrapperAndRegisteredTracerTest extends BaseTest {
 
   @BeforeClass

--- a/opentracing-spring-tracer-configuration-starter/src/test/java/io/opentracing/contrib/spring/tracer/configuration/TracerAutoConfigurationWithWrapperTest.java
+++ b/opentracing-spring-tracer-configuration-starter/src/test/java/io/opentracing/contrib/spring/tracer/configuration/TracerAutoConfigurationWithWrapperTest.java
@@ -22,6 +22,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 @SpringBootTest(
@@ -29,6 +30,7 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
                 BaseTest.SpringConfiguration.class,
                 TestTracerBeanPostProcessor.class})
 @RunWith(SpringJUnit4ClassRunner.class)
+@DirtiesContext
 public class TracerAutoConfigurationWithWrapperTest extends BaseTest {
 
   @Autowired

--- a/pom.xml
+++ b/pom.xml
@@ -58,9 +58,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <main.basedir>${project.basedir}</main.basedir>
 
-    <!-- spring-boot-starter-parent is a module of spring-boot-dependencies
-        https://github.com/spring-projects/spring-boot/blob/master/spring-boot-starters/spring-boot-starter-parent/pom.xml -->
-    <version.org.springframework.boot>2.3.4.RELEASE</version.org.springframework.boot>
+    <version.org.springframework.boot>2.7.17</version.org.springframework.boot>
     <version.io.opentracing.contrib-opentracing-tracerresolver>0.1.8</version.io.opentracing.contrib-opentracing-tracerresolver>
     <version.io.opentracing>0.33.0</version.io.opentracing>
     <version.junit>4.12</version.junit>


### PR DESCRIPTION
spring factories is deprecated by spring boot 2.7 and completely removed in 3.0+

fixes #13 